### PR TITLE
Fix prez annz

### DIFF
--- a/news/php/news_articles_archive.php
+++ b/news/php/news_articles_archive.php
@@ -96,6 +96,11 @@ function inspect_news_archive_page($xml, $categories){
     $page_info['month'] = date("m", $date_for_sorting);
     $page_info['month-name'] = date("F", $date_for_sorting);
 
+    if( in_array('president/announcements', $_SERVER['REQUEST_URI']) ) {
+        $options = array('school', 'topic', 'department', 'adult-undergrad-program', 'graduate-program', 'seminary-program', 'unique-news');
+        $page_info['display-on-feed'] = match_metadata_articles($xml, $categories, $options, "news");
+    }
+
     $page_info['html'] = get_news_article_archive_html($page_info);
 
     return $page_info;

--- a/news/php/news_articles_archive.php
+++ b/news/php/news_articles_archive.php
@@ -96,7 +96,7 @@ function inspect_news_archive_page($xml, $categories){
     $page_info['month'] = date("m", $date_for_sorting);
     $page_info['month-name'] = date("F", $date_for_sorting);
 
-    if( in_array('president/announcements', $_SERVER['REQUEST_URI']) ) {
+    if( strpos($_SERVER['REQUEST_URI'], 'president/announcements') !== false ) {
         $options = array('school', 'topic', 'department', 'adult-undergrad-program', 'graduate-program', 'seminary-program', 'unique-news');
         $page_info['display-on-feed'] = match_metadata_articles($xml, $categories, $options, "news");
     }


### PR DESCRIPTION
## Description

The news archive wasn't working due to not checking for metadata (my bad). I removed that a few months ago because it was causing issues for the main news feed. I didn't realize that we also used it for president announcements.

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

- Tested this on staging and it works like a charm for both the news archive and the president news archive.
- https://staging.bethel.edu/news/archive and https://staging.bethel.edu/president/announcements/ (no 2019 announcements yet)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
