### PR TITLE
Remove president announcements from bethel.edu/news/archive

### DIFF
--- a/news/php/news_articles_archive.php
+++ b/news/php/news_articles_archive.php
@@ -70,6 +70,7 @@ function inspect_news_archive_page($xml, $categories){
     // To get the correct definition path.
     $dataDefinition = $ds['definition-path'];
 
+
     $year_works = false;
     for( $i = 2012; $i <= intval(date("Y")); $i++ ){
         if( strstr($xml->path, "/$i/") ){
@@ -77,6 +78,7 @@ function inspect_news_archive_page($xml, $categories){
             break;
         }
     }
+    // Get the correct date, depending on which Data Definition you are dealing with.
     if( $year_works ) {
         if( $dataDefinition == "News Article") {
             $date_for_sorting = $xml->{'system-data-structure'}->{'publish-date'} / 1000;
@@ -109,6 +111,21 @@ function inspect_news_archive_page($xml, $categories){
             $options = array('school', 'topic', 'department', 'adult-undergrad-program', 'graduate-program', 'seminary-program', 'unique-news');
             $page_info['display-on-feed'] = match_metadata_articles($xml, $categories, $options, "news");
         }
+    } else {
+        # if its not the president announcements page, we want to make sure that the prez announcements are NOT shown.
+        foreach ($xml->{'dynamic-metadata'} as $md) {
+            $name = $md->name;
+
+            foreach ($md->value as $value) {
+                if (strtolower($value) == "none" || strtolower($value) == "select") {
+                    continue;
+                }
+                if ( $name == 'unique-news' && in_array($value, ['President Announcements', 'President Announcements - Strategic plan', 'Internal']) ) {
+                    return "";
+                }
+            }
+        }
+
     }
 
     $page_info['html'] = get_news_article_archive_html($page_info);

--- a/news/php/news_articles_archive.php
+++ b/news/php/news_articles_archive.php
@@ -115,11 +115,8 @@ function inspect_news_archive_page($xml, $categories){
         # if its not the president announcements page, we want to make sure that the prez announcements are NOT shown.
         foreach ($xml->{'dynamic-metadata'} as $md) {
             $name = $md->name;
-
+ß
             foreach ($md->value as $value) {
-                if (strtolower($value) == "none" || strtolower($value) == "select") {
-                    continue;
-                }
                 if ( $name == 'unique-news' && in_array($value, ['President Announcements', 'President Announcements - Strategic plan', 'Internal']) ) {
                     return "";
                 }


### PR DESCRIPTION
## Description

We want to hide the Announcements for the bethel.edu/news/archive page. This is a bit nasty, but its a quick fix. I didn't want to take the time to develop a cleaner way to do it. I'm doing a check to find any "President" values in the "unique-news" metadata section of the news articles.

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

- I pulled on staging.bethel.edu. It looks great. I verified that none of the president announcements were in the list.

## Checklist:

Only check what applies and what you have done.

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
