### PR TITLE
Bethel alert cache clear

### DIFF
--- a/config.php.dist
+++ b/config.php.dist
@@ -10,3 +10,6 @@ if( isset($config) && !is_array($config) )
      $config = array();
 
 $config['RAVEN_URL'] = '';
+
+$config['CACHE_CLEAR_USER'] = '';
+$config['CACHE_CLEAR_PASS'] = '';

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -285,7 +285,7 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_this_sometime
         echo 'DID IT GET HERE';
         $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
         $cache_keys = cache.get($bethel_alert_cache_name);
-        if( $cache_keys ){
+        if( $cache_keys ) {
             $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time);
         } else {
             // cache this for 5x the normal cache time. This will help us maintain this list for a longer period of time.

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -296,6 +296,7 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_
 
     $data = $cache->get($cache_name);
     if (!$data) {
+        echo "NO CACHE";
         $msg = "\nFull Data Array Memcache miss at " . $_SERVER['REQUEST_URI'] . "\n";
         error_log($msg, 3, '/opt/php_logs/memcache.log');
         $data = call_user_func_array($func, $inputs);

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -228,7 +228,8 @@ function makeTwigEnviron($path){
 
 }
 
-function autoCache($func, $inputs=array(), $cache_time=300){
+function autoCache($func, $inputs=array(), $cache_time=300, $clear_this_sometime_later=false, $clear_cache_bethel_alert="No"){
+
     if( !is_int($cache_time) )
         $cache_time = 300;
 
@@ -278,6 +279,19 @@ function autoCache($func, $inputs=array(), $cache_time=300){
     //checks if cache_name is being used. if so it retrieves it's data otherwise it creates a new key using cache_name
     $cache = new Memcache;
     $cache->connect('localhost', 11211);
+
+    // store bethel alert cache clearing
+    if( $clear_cache_bethel_alert == 'Yes' ) {
+        $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
+        $cache_keys = cache.get($bethel_alert_cache_name);
+        if( $cache_keys ){
+            $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time);
+        } else {
+            // cache this for 5x the normal cache time. This will help us maintain this list for a longer period of time.
+            $cache->set($bethel_alert_cache_name, $cache_name, MEMCACHE_COMPRESSED, $cache_time*5);
+        }
+    }
+
     $data = $cache->get($cache_name);
     if (!$data) {
         $msg = "\nFull Data Array Memcache miss at " . $_SERVER['REQUEST_URI'] . "\n";

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -279,13 +279,13 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_this_sometime
     //checks if cache_name is being used. if so it retrieves it's data otherwise it creates a new key using cache_name
     $cache = new Memcache;
     $cache->connect('localhost', 11211);
-
+    echo "TEST";
     // store bethel alert cache clearing
     if( $clear_cache_bethel_alert == 'Yes' ) {
         $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
         $cache_keys = $cache.get($bethel_alert_cache_name);
         if( $cache_keys ) {
-            $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time);
+            $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time*5);
         } else {
             // cache this for 5x the normal cache time. This will help us maintain this list for a longer period of time.
             $cache->set($bethel_alert_cache_name, $cache_name, MEMCACHE_COMPRESSED, $cache_time*5);

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -279,11 +279,12 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_this_sometime
     //checks if cache_name is being used. if so it retrieves it's data otherwise it creates a new key using cache_name
     $cache = new Memcache;
     $cache->connect('localhost', 11211);
-    echo "TEST";
+    echo $clear_cache_bethel_alert;
     // store bethel alert cache clearing
     if( $clear_cache_bethel_alert == 'Yes' ) {
         $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
         $cache_keys = $cache.get($bethel_alert_cache_name);
+        echo $cache_keys;
         if( $cache_keys ) {
             $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time*5);
         } else {

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -228,7 +228,7 @@ function makeTwigEnviron($path){
 
 }
 
-function autoCache($func, $inputs=array(), $cache_time=300, $clear_this_sometime_later=false, $clear_cache_bethel_alert="No"){
+function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_alert="No"){
     echo $clear_cache_bethel_alert;
     echo '____';
     if( !is_int($cache_time) )

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -229,8 +229,6 @@ function makeTwigEnviron($path){
 }
 
 function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_alert="No"){
-    echo $clear_cache_bethel_alert;
-    echo '____';
     if( !is_int($cache_time) )
         $cache_time = 300;
 
@@ -280,12 +278,10 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_
     //checks if cache_name is being used. if so it retrieves it's data otherwise it creates a new key using cache_name
     $cache = new Memcache;
     $cache->connect('localhost', 11211);
-    echo $clear_cache_bethel_alert;
     // store bethel alert cache clearing
     if( $clear_cache_bethel_alert == 'Yes' ) {
         $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
         $cache_keys = $cache->get($bethel_alert_cache_name);
-        echo $cache_keys;
         if( $cache_keys ) {
             $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time*5);
         } else {

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -282,6 +282,7 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_this_sometime
 
     // store bethel alert cache clearing
     if( $clear_cache_bethel_alert == 'Yes' ) {
+        echo 'DID IT GET HERE';
         $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
         $cache_keys = cache.get($bethel_alert_cache_name);
         if( $cache_keys ){
@@ -290,6 +291,7 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_this_sometime
             // cache this for 5x the normal cache time. This will help us maintain this list for a longer period of time.
             $cache->set($bethel_alert_cache_name, $cache_name, MEMCACHE_COMPRESSED, $cache_time*5);
         }
+        echo "$cache->get($bethel_alert_cache_name)";
     }
 
     $data = $cache->get($cache_name);

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -229,6 +229,7 @@ function makeTwigEnviron($path){
 }
 
 function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_alert="No"){
+    echo $clear_cache_bethel_alert;
     if( !is_int($cache_time) )
         $cache_time = 300;
 
@@ -283,7 +284,9 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_
         $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
         $cache_keys = $cache->get($bethel_alert_cache_name);
         if( $cache_keys ) {
-            $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time*5);
+            // if the cache name isn't in it.
+            if( strpos($cache_keys, $cache_name) == false )
+                $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time*5);
         } else {
             // cache this for 5x the normal cache time. This will help us maintain this list for a longer period of time.
             $cache->set($bethel_alert_cache_name, $cache_name, MEMCACHE_COMPRESSED, $cache_time*5);

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -282,16 +282,14 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_this_sometime
 
     // store bethel alert cache clearing
     if( $clear_cache_bethel_alert == 'Yes' ) {
-        echo 'DID IT GET HERE';
         $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
-        $cache_keys = cache.get($bethel_alert_cache_name);
+        $cache_keys = $cache.get($bethel_alert_cache_name);
         if( $cache_keys ) {
             $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time);
         } else {
             // cache this for 5x the normal cache time. This will help us maintain this list for a longer period of time.
             $cache->set($bethel_alert_cache_name, $cache_name, MEMCACHE_COMPRESSED, $cache_time*5);
         }
-        echo "$cache->get($bethel_alert_cache_name)";
     }
 
     $data = $cache->get($cache_name);

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -284,6 +284,9 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_
         $cache_keys = $cache->get($bethel_alert_cache_name);
         if( $cache_keys ) {
             // if the cache name isn't in it.
+            echo $cache_keys;
+            echo '|';
+            echo $cache_name;
             if( strpos($cache_keys, $cache_name) == false )
                 $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time*5);
         } else {

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -229,7 +229,8 @@ function makeTwigEnviron($path){
 }
 
 function autoCache($func, $inputs=array(), $cache_time=300, $clear_this_sometime_later=false, $clear_cache_bethel_alert="No"){
-
+    echo $clear_cache_bethel_alert;
+    echo '____';
     if( !is_int($cache_time) )
         $cache_time = 300;
 

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -229,7 +229,6 @@ function makeTwigEnviron($path){
 }
 
 function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_alert="No"){
-    echo $clear_cache_bethel_alert;
     if( !is_int($cache_time) )
         $cache_time = 300;
 
@@ -294,7 +293,6 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_
     }
 
     $data = $cache->get($cache_name);
-    echo $cache_name;
     if (!$data) {
         echo "NO CACHE";
         $msg = "\nFull Data Array Memcache miss at " . $_SERVER['REQUEST_URI'] . "\n";
@@ -302,9 +300,8 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_
         $data = call_user_func_array($func, $inputs);
         try {
             $cache->set($cache_name, $data, MEMCACHE_COMPRESSED, $cache_time);
-
         } catch (Exception $e) {
-            $msg = "\nError - " . $e->getMessage() . "at " . $_SERVER['REQUEST_URI'] . "\n";
+            $msg = "\nError - " . $e->getMessage() . " at " . $_SERVER['REQUEST_URI'] . "\n";
             error_log($msg, 3, '/opt/php_logs/memcache.log');
         }
     }

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -294,6 +294,7 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_
     }
 
     $data = $cache->get($cache_name);
+    echo $cache_name;
     if (!$data) {
         echo "NO CACHE";
         $msg = "\nFull Data Array Memcache miss at " . $_SERVER['REQUEST_URI'] . "\n";

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -284,7 +284,7 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_
         $cache_keys = $cache->get($bethel_alert_cache_name);
         if( $cache_keys ) {
             // if the cache name isn't in it.
-            if( strpos(strval($cache_keys), strval($cache_name)) == false )
+            if( strpos($cache_keys, $cache_name) === false )
                 $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time*5);
         } else {
             // cache this for 5x the normal cache time. This will help us maintain this list for a longer period of time.

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -294,7 +294,6 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_
 
     $data = $cache->get($cache_name);
     if (!$data) {
-        echo "NO CACHE";
         $msg = "\nFull Data Array Memcache miss at " . $_SERVER['REQUEST_URI'] . "\n";
         error_log($msg, 3, '/opt/php_logs/memcache.log');
         $data = call_user_func_array($func, $inputs);

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -284,10 +284,7 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_
         $cache_keys = $cache->get($bethel_alert_cache_name);
         if( $cache_keys ) {
             // if the cache name isn't in it.
-            echo $cache_keys;
-            echo '|';
-            echo $cache_name;
-            if( strpos($cache_keys, $cache_name) == false )
+            if( strpos($cache_keys, strval($cache_name)) == false )
                 $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time*5);
         } else {
             // cache this for 5x the normal cache time. This will help us maintain this list for a longer period of time.

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -284,7 +284,7 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_
     // store bethel alert cache clearing
     if( $clear_cache_bethel_alert == 'Yes' ) {
         $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
-        $cache_keys = $cache.get($bethel_alert_cache_name);
+        $cache_keys = $cache->get($bethel_alert_cache_name);
         echo $cache_keys;
         if( $cache_keys ) {
             $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time*5);

--- a/general-cascade/macros.php
+++ b/general-cascade/macros.php
@@ -284,7 +284,7 @@ function autoCache($func, $inputs=array(), $cache_time=300, $clear_cache_bethel_
         $cache_keys = $cache->get($bethel_alert_cache_name);
         if( $cache_keys ) {
             // if the cache name isn't in it.
-            if( strpos($cache_keys, strval($cache_name)) == false )
+            if( strpos(strval($cache_keys), strval($cache_name)) == false )
                 $cache->set($bethel_alert_cache_name, "$cache_keys:$cache_name", MEMCACHE_COMPRESSED, $cache_time*5);
         } else {
             // cache this for 5x the normal cache time. This will help us maintain this list for a longer period of time.

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -21,7 +21,7 @@ $DisplayImages;
 $featuredArticleOptions;
 
 function create_news_article_feed($categories, $clearCacheBethelAlert="No"){
-    $feed = autoCache("create_news_article_feed_logic", array($categories, $clear_cache_bethel_alert=$clearCacheBethelAlert));
+    $feed = autoCache("create_news_article_feed_logic", array($categories), $clear_cache_bethel_alert=$clearCacheBethelAlert);
     return $feed;
 }
 

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -20,9 +20,8 @@ $DisplayImages;
 
 $featuredArticleOptions;
 
-function create_news_article_feed($categories){
-    $feed = autoCache("create_news_article_feed_logic", array($categories));
-//    $feed = create_news_article_feed_logic($categories);
+function create_news_article_feed($categories, $clearCacheBethelAlert="No"){
+    $feed = autoCache("create_news_article_feed_logic", array($categories, $clear_cache_bethel_alert=$clearCacheBethelAlert));
     return $feed;
 }
 
@@ -37,11 +36,9 @@ function create_news_article_feed_logic($categories){
     }
 
     // this is legacy code. It will be used for the archive and for any feed that includes old articles
-//    $arrayOfArticles = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/articles.xml", $categories, "inspect_news_article"));
     $arrayOfArticles = get_xml($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/articles.xml", $categories, "inspect_news_article");
 
     // This is the new version of news.
-//    $arrayOfNewsAndStories = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article"), 10);
     $arrayOfNewsAndStories = get_xml($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article");
 
 

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -22,7 +22,7 @@ $featuredArticleOptions;
 
 function create_news_article_feed($categories, $clearCacheBethelAlert="No"){
     echo $clearCacheBethelAlert;
-    $feed = autoCache("create_news_article_feed_logic", array($categories), $clear_cache_bethel_alert=$clearCacheBethelAlert);
+    $feed = autoCache("create_news_article_feed_logic", array($categories), 300, $clearCacheBethelAlert);
     return $feed;
 }
 

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -21,6 +21,7 @@ $DisplayImages;
 $featuredArticleOptions;
 
 function create_news_article_feed($categories, $clearCacheBethelAlert="No"){
+    echo $clearCacheBethelAlert;
     $feed = autoCache("create_news_article_feed_logic", array($categories), $clear_cache_bethel_alert=$clearCacheBethelAlert);
     return $feed;
 }

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -21,7 +21,6 @@ $DisplayImages;
 $featuredArticleOptions;
 
 function create_news_article_feed($categories, $clearCacheBethelAlert="No"){
-    echo $clearCacheBethelAlert;
     $feed = autoCache("create_news_article_feed_logic", array($categories), 300, $clearCacheBethelAlert);
     return $feed;
 }

--- a/news/php/news_article_feed_clear_cache.php
+++ b/news/php/news_article_feed_clear_cache.php
@@ -16,16 +16,22 @@ $cache = new Memcache;
 $cache->connect('localhost', 11211);
 
 $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
+
 $cache_keys = $cache->get($bethel_alert_cache_name);
 echo "Cache Keys: $cache_keys";
-if( $cache_keys ){
-    foreach($cache_keys.explode(':') as $cache_key){
-        echo "Cache Key: $cache_key";
-        $cache->delete($cache_key);
-    }
-    $cache->delete($bethel_alert_cache_name);
-}
-echo 'Cleared Cache!';
+$cache->set($bethel_alert_cache_name,MEMCACHE_COMPRESSED, 300);
+$cache_keys = $cache->get($bethel_alert_cache_name);
+echo "Cache Keys: $cache_keys";
+
+
+//if( $cache_keys ){
+//    foreach($cache_keys.explode(':') as $cache_key){
+//        echo "Cache Key: $cache_key";
+//        $cache->delete($cache_key);
+//    }
+//    $cache->delete($bethel_alert_cache_name);
+//}
+//echo 'Cleared Cache!';
 
 
 ?>

--- a/news/php/news_article_feed_clear_cache.php
+++ b/news/php/news_article_feed_clear_cache.php
@@ -21,7 +21,7 @@ $cache_keys = $cache->get($bethel_alert_cache_name);
 $cache_keys_array = explode(':', $cache_keys);
 echo "Cache Keys: $cache_keys";
 
-if( sizeof($cache_keys) > 0 ){
+if( $cache_keys ){
     echo 'HERE WE GO';
     foreach($cache_keys_array as $cache_key){
         echo "Cache Key: $cache_key";

--- a/news/php/news_article_feed_clear_cache.php
+++ b/news/php/news_article_feed_clear_cache.php
@@ -17,11 +17,13 @@ $cache->connect('localhost', 11211);
 
 $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
 
+$cache->set($bethel_alert_cache_name, 'BLAH', MEMCACHE_COMPRESSED, 300);
+
 $cache_keys = $cache->get($bethel_alert_cache_name);
 echo "Cache Keys: $cache_keys";
 
 if( $cache_keys ){
-    echo 'TEST';
+    echo 'HERE WE GO';
     foreach($cache_keys.explode(':') as $cache_key){
         echo "Cache Key: $cache_key";
         $cache->delete($cache_key);

--- a/news/php/news_article_feed_clear_cache.php
+++ b/news/php/news_article_feed_clear_cache.php
@@ -1,11 +1,10 @@
 <?php
-$valid_passwords = array ("mario" => "carbonell");
-$valid_users = array_keys($valid_passwords);
+include_once $_SERVER["DOCUMENT_ROOT"] . "/code/config.php";
 
 $user = $_SERVER['PHP_AUTH_USER'];
 $pass = $_SERVER['PHP_AUTH_PW'];
 
-$validated = (in_array($user, $valid_users)) && ($pass == $valid_passwords[$user]);
+$validated = ($user == $config['RAVEN_URL']) && ($pass == $config['RAVEN_URL']);
 
 if (!$validated) {
     header('WWW-Authenticate: Basic realm="My Realm"');
@@ -13,21 +12,20 @@ if (!$validated) {
     die ("Not authorized");
 }
 
-// If arrives here, is a valid user.
-echo "<p>Welcome $user.</p>";
-echo "<p>Congratulation, you are into the system.</p>";
+$cache = new Memcache;
+$cache->connect('localhost', 11211);
 
-
-//$cache = new Memcache;
-//$cache->connect('localhost', 11211);
-//
-//$bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
-//$cache_keys = cache.get($bethel_alert_cache_name);
-//if( $cache_keys ){
-//    foreach($cache_keys.explode(':') as $cache_key){
-//        $cache->delete($cache_key);
-//    }
-//}
+$bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
+$cache_keys = $cache->get($bethel_alert_cache_name);
+echo "Cache Keys: $cache_keys";
+if( $cache_keys ){
+    foreach($cache_keys.explode(':') as $cache_key){
+        echo "Cache Key: $cache_key";
+        $cache->delete($cache_key);
+    }
+    $cache->delete($bethel_alert_cache_name);
+}
+echo 'Cleared Cache!';
 
 
 ?>

--- a/news/php/news_article_feed_clear_cache.php
+++ b/news/php/news_article_feed_clear_cache.php
@@ -19,18 +19,13 @@ $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
 
 $cache_keys = $cache->get($bethel_alert_cache_name);
 $cache_keys_array = explode(':', $cache_keys);
-print_r("Cache Keys: $cache_keys");
 
 if( $cache_keys ){
-    echo 'HERE WE GO';
     foreach($cache_keys_array as $cache_key){
-        echo "Cache Key: $cache_key";
         $cache->delete($cache_key);
     }
     $cache->delete($bethel_alert_cache_name);
-    echo 'Cleared Cache!';
 }
-
 
 ?>
 

--- a/news/php/news_article_feed_clear_cache.php
+++ b/news/php/news_article_feed_clear_cache.php
@@ -1,0 +1,34 @@
+<?php
+$valid_passwords = array ("mario" => "carbonell");
+$valid_users = array_keys($valid_passwords);
+
+$user = $_SERVER['PHP_AUTH_USER'];
+$pass = $_SERVER['PHP_AUTH_PW'];
+
+$validated = (in_array($user, $valid_users)) && ($pass == $valid_passwords[$user]);
+
+if (!$validated) {
+    header('WWW-Authenticate: Basic realm="My Realm"');
+    header('HTTP/1.0 401 Unauthorized');
+    die ("Not authorized");
+}
+
+// If arrives here, is a valid user.
+echo "<p>Welcome $user.</p>";
+echo "<p>Congratulation, you are into the system.</p>";
+
+
+//$cache = new Memcache;
+//$cache->connect('localhost', 11211);
+//
+//$bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
+//$cache_keys = cache.get($bethel_alert_cache_name);
+//if( $cache_keys ){
+//    foreach($cache_keys.explode(':') as $cache_key){
+//        $cache->delete($cache_key);
+//    }
+//}
+
+
+?>
+

--- a/news/php/news_article_feed_clear_cache.php
+++ b/news/php/news_article_feed_clear_cache.php
@@ -20,11 +20,12 @@ $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
 $cache->set($bethel_alert_cache_name, 'BLAH', MEMCACHE_COMPRESSED, 300);
 
 $cache_keys = $cache->get($bethel_alert_cache_name);
+$cache_keys_array = explode(':', $cache_keys);
 echo "Cache Keys: $cache_keys";
 
-if( $cache_keys ){
+if( sizeof($cache_keys) > 0 ){
     echo 'HERE WE GO';
-    foreach($cache_keys.explode(':') as $cache_key){
+    foreach($cache_keys_array as $cache_key){
         echo "Cache Key: $cache_key";
         $cache->delete($cache_key);
     }

--- a/news/php/news_article_feed_clear_cache.php
+++ b/news/php/news_article_feed_clear_cache.php
@@ -19,7 +19,7 @@ $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
 
 $cache_keys = $cache->get($bethel_alert_cache_name);
 $cache_keys_array = explode(':', $cache_keys);
-echo "Cache Keys: $cache_keys";
+print_r("Cache Keys: $cache_keys");
 
 if( $cache_keys ){
     echo 'HERE WE GO';
@@ -28,8 +28,8 @@ if( $cache_keys ){
         $cache->delete($cache_key);
     }
     $cache->delete($bethel_alert_cache_name);
+    echo 'Cleared Cache!';
 }
-echo 'Cleared Cache!';
 
 
 ?>

--- a/news/php/news_article_feed_clear_cache.php
+++ b/news/php/news_article_feed_clear_cache.php
@@ -4,7 +4,7 @@ include_once $_SERVER["DOCUMENT_ROOT"] . "/code/config.php";
 $user = $_SERVER['PHP_AUTH_USER'];
 $pass = $_SERVER['PHP_AUTH_PW'];
 
-$validated = ($user == $config['RAVEN_URL']) && ($pass == $config['RAVEN_URL']);
+$validated = ($user == $config['CACHE_CLEAR_USER']) && ($pass == $config['CACHE_CLEAR_PASS']);
 
 if (!$validated) {
     header('WWW-Authenticate: Basic realm="My Realm"');

--- a/news/php/news_article_feed_clear_cache.php
+++ b/news/php/news_article_feed_clear_cache.php
@@ -17,8 +17,6 @@ $cache->connect('localhost', 11211);
 
 $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
 
-$cache->set($bethel_alert_cache_name, 'BLAH', MEMCACHE_COMPRESSED, 300);
-
 $cache_keys = $cache->get($bethel_alert_cache_name);
 $cache_keys_array = explode(':', $cache_keys);
 echo "Cache Keys: $cache_keys";

--- a/news/php/news_article_feed_clear_cache.php
+++ b/news/php/news_article_feed_clear_cache.php
@@ -19,7 +19,7 @@ $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
 
 $cache_keys = $cache->get($bethel_alert_cache_name);
 echo "Cache Keys: $cache_keys";
-$cache->set($bethel_alert_cache_name,MEMCACHE_COMPRESSED, 300);
+$cache->set($bethel_alert_cache_name,'TEST',MEMCACHE_COMPRESSED, 300);
 $cache_keys = $cache->get($bethel_alert_cache_name);
 echo "Cache Keys: $cache_keys";
 

--- a/news/php/news_article_feed_clear_cache.php
+++ b/news/php/news_article_feed_clear_cache.php
@@ -19,19 +19,16 @@ $bethel_alert_cache_name = 'clear_cache_bethel_alert_keys';
 
 $cache_keys = $cache->get($bethel_alert_cache_name);
 echo "Cache Keys: $cache_keys";
-$cache->set($bethel_alert_cache_name,'TEST',MEMCACHE_COMPRESSED, 300);
-$cache_keys = $cache->get($bethel_alert_cache_name);
-echo "Cache Keys: $cache_keys";
 
-
-//if( $cache_keys ){
-//    foreach($cache_keys.explode(':') as $cache_key){
-//        echo "Cache Key: $cache_key";
-//        $cache->delete($cache_key);
-//    }
-//    $cache->delete($bethel_alert_cache_name);
-//}
-//echo 'Cleared Cache!';
+if( $cache_keys ){
+    echo 'TEST';
+    foreach($cache_keys.explode(':') as $cache_key){
+        echo "Cache Key: $cache_key";
+        $cache->delete($cache_key);
+    }
+    $cache->delete($bethel_alert_cache_name);
+}
+echo 'Cleared Cache!';
 
 
 ?>

--- a/news/php/news_article_gallery_feed.php
+++ b/news/php/news_article_gallery_feed.php
@@ -13,7 +13,7 @@ include_once $_SERVER["DOCUMENT_ROOT"] . "/code/general-cascade/macros.php";
 require $_SERVER["DOCUMENT_ROOT"] . '/code/vendor/autoload.php';
 
 
-function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel, $newsOrStories = "Stories"){
+function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel, $newsOrStories = "Stories", $clearCacheBethelAlert='No'){
     // set $DisplayImages and $DisplayTeaser to Yes, as it is used for the normal feeds - so we need to still set those
     global $DisplayImages;
     $DisplayImages = 'Yes';
@@ -32,7 +32,7 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
 
     // This is the new version of news.
     // TODO: currently the cached version is broken. It caches a BAD value.
-    $arrayOfNewsAndStories = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article"));
+    $arrayOfNewsAndStories = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article"), $clear_cache_bethel_alert=$clearCacheBethelAlert);
 //    $arrayOfNewsAndStories = get_xml($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article");
     $arrayOfNewsAndStories = sort_by_date($arrayOfNewsAndStories);
 

--- a/news/php/news_article_gallery_feed.php
+++ b/news/php/news_article_gallery_feed.php
@@ -26,14 +26,10 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
     }
 
     // this is legacy code. It will be used for the archive and for any feed that includes old articles
-    // TODO: currently the cached version is broken. It caches a BAD value.
     $arrayOfArticles = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/articles.xml", $categories, "inspect_news_article"));
-//    $arrayOfArticles = get_xml($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/articles.xml", $categories, "inspect_news_article");
 
     // This is the new version of news.
-    // TODO: currently the cached version is broken. It caches a BAD value.
     $arrayOfNewsAndStories = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article"), $clear_cache_bethel_alert=$clearCacheBethelAlert);
-//    $arrayOfNewsAndStories = get_xml($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article");
     $arrayOfNewsAndStories = sort_by_date($arrayOfNewsAndStories);
 
     $includeStories = false;

--- a/news/php/news_article_gallery_feed.php
+++ b/news/php/news_article_gallery_feed.php
@@ -29,7 +29,7 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
     $arrayOfArticles = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/articles.xml", $categories, "inspect_news_article"));
 
     // This is the new version of news.
-    $arrayOfNewsAndStories = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article"), $clear_cache_bethel_alert=$clearCacheBethelAlert);
+    $arrayOfNewsAndStories = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article"), 300, $clearCacheBethelAlert);
     $arrayOfNewsAndStories = sort_by_date($arrayOfNewsAndStories);
 
     $includeStories = false;

--- a/news/php/news_articles_archive.php
+++ b/news/php/news_articles_archive.php
@@ -11,7 +11,7 @@
 $yearChosen;
 $uniqueNews;
 // returns an array of html elements.
-function create_news_article_archive($categories){
+function create_news_article_archive($categories, $clearCacheBethelAlert="No"){
     include_once $_SERVER["DOCUMENT_ROOT"] . "/code/php_helper_for_cascade.php";
     include_once $_SERVER["DOCUMENT_ROOT"] . "/code/general-cascade/feed_helper.php";
 
@@ -25,7 +25,7 @@ function create_news_article_archive($categories){
         $arrayOfArticles = array_merge($arrayOfArticles, $arrayOfNewsAndStories);
     }
 
-    $arrayOfArticles = autoCache("sort_news_articles", array($arrayOfArticles));
+    $arrayOfArticles = autoCache("sort_news_articles", array($arrayOfArticles), $clear_cache_bethel_alert=$clearCacheBethelAlert);
     $arrayOfArticles = array_reverse($arrayOfArticles);
 
     $twig = makeTwigEnviron('/code/news/twig');

--- a/news/php/news_articles_archive.php
+++ b/news/php/news_articles_archive.php
@@ -12,6 +12,7 @@ $yearChosen;
 $uniqueNews;
 // returns an array of html elements.
 function create_news_article_archive($categories, $clearCacheBethelAlert="No"){
+    echo $clearCacheBethelAlert;
     include_once $_SERVER["DOCUMENT_ROOT"] . "/code/php_helper_for_cascade.php";
     include_once $_SERVER["DOCUMENT_ROOT"] . "/code/general-cascade/feed_helper.php";
 

--- a/news/php/news_articles_archive.php
+++ b/news/php/news_articles_archive.php
@@ -12,7 +12,6 @@ $yearChosen;
 $uniqueNews;
 // returns an array of html elements.
 function create_news_article_archive($categories, $clearCacheBethelAlert="No"){
-    echo $clearCacheBethelAlert;
     include_once $_SERVER["DOCUMENT_ROOT"] . "/code/php_helper_for_cascade.php";
     include_once $_SERVER["DOCUMENT_ROOT"] . "/code/general-cascade/feed_helper.php";
 
@@ -26,20 +25,26 @@ function create_news_article_archive($categories, $clearCacheBethelAlert="No"){
         $arrayOfArticles = array_merge($arrayOfArticles, $arrayOfNewsAndStories);
     }
 
-    $arrayOfArticles = autoCache("sort_news_articles", array($arrayOfArticles), 300, $clearCacheBethelAlert);
+    $arrayOfArticles = sort_news_articles($arrayOfArticles);
     $arrayOfArticles = array_reverse($arrayOfArticles);
 
-    $twig = makeTwigEnviron('/code/news/twig');
+    echo autoCache("echo_articles", array($arrayOfArticles), 300, $clearCacheBethelAlert);
 
+    return;
+}
+
+function echo_articles($arrayOfArticles) {
+    $twig = makeTwigEnviron('/code/news/twig');
+    $return_str = '';
     foreach( $arrayOfArticles as $yearArray )
     {
         // This should return an array of 5 items. Each of those includes a full years worth of articles, pre-sorted, and including the headers.
         //twig version
-        echo $twig->render('news_article_archive.html',array(
+        $return_str .= $twig->render('news_article_archive.html',array(
             'yearArray' => $yearArray
         ));
     }
-    return;
+    return $return_str;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/news/php/news_articles_archive.php
+++ b/news/php/news_articles_archive.php
@@ -25,7 +25,7 @@ function create_news_article_archive($categories, $clearCacheBethelAlert="No"){
         $arrayOfArticles = array_merge($arrayOfArticles, $arrayOfNewsAndStories);
     }
 
-    $arrayOfArticles = autoCache("sort_news_articles", array($arrayOfArticles), $clear_cache_bethel_alert=$clearCacheBethelAlert);
+    $arrayOfArticles = autoCache("sort_news_articles", array($arrayOfArticles), 300, $clearCacheBethelAlert);
     $arrayOfArticles = array_reverse($arrayOfArticles);
 
     $twig = makeTwigEnviron('/code/news/twig');


### PR DESCRIPTION
## Description

Bethel alerts need to have their cache cleared when a new one is created. This PR holds the data to be able to clear only the caches of specific feeds we want cleared.

## Size and Type of change

- Small Change - 1 person needs to review this
- New feature
- Config update

## How Has This Been Tested?

- I have tested this branch on staging, it works great!

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
