### PR TITLE
Coronavirus updates

### DIFF
--- a/news/php/news_article_gallery_feed.php
+++ b/news/php/news_article_gallery_feed.php
@@ -49,6 +49,7 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
     foreach( $arrayOfNewsAndStories as $index => $newsAndStory) {
         $id = $newsAndStory['id'];
         $addArticle = false;
+        $coronavirusArticleId = 'c0a958b58c5865fc6f6501cb65bc8c89';
 
         // if it's already been used, skip this article
         // if its the Homepage Top Feature, skip any that aren't tagged as homepage
@@ -56,7 +57,8 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
             continue;
 
         // Check if the what the feed type is the same as the article type
-        if( ($includeNews && $newsAndStory['article-type'] == 'News') || ($includeStories && $newsAndStory['article-type'] == 'Story') ) {
+        // The last check is the coronavirus check
+        if( (($includeNews && $newsAndStory['article-type'] == 'News') || ($includeStories && $newsAndStory['article-type'] == 'Story')) || ( $galleryStyle == 'Homepage Top Feature' && $id == $coronavirusArticleId)) {
             // We add the mybethel class for the community dashboard
             $add_mybethel_class = '';
             if( strpos($_SERVER['REQUEST_URI'], '_portal/') !== false )

--- a/news/php/news_article_gallery_feed.php
+++ b/news/php/news_article_gallery_feed.php
@@ -29,8 +29,7 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
     $arrayOfArticles = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/articles.xml", $categories, "inspect_news_article"));
 
     // This is the new version of news.
-//    $arrayOfNewsAndStories = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article"), 300, $clearCacheBethelAlert);
-    $arrayOfNewsAndStories = get_xml($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article");
+    $arrayOfNewsAndStories = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article"), 300, $clearCacheBethelAlert);
 
     $arrayOfNewsAndStories = sort_by_date($arrayOfNewsAndStories);
 
@@ -48,7 +47,7 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
 
     $threeStories = array();
     $onlyLookForCoronavirus = False;
-    $coronavirusArticleId = 'c0a958b58c5865fc6f6501cb65bc8c89';
+    $coronavirusArticleId = 'c0a958b58c5865fc6f6501cb65bc8c89'; // TODO: THIS CAN BE REMOVED ONCE WE DON't HAVE THE CORNAVIRUS ARTICLE
 
     foreach( $arrayOfNewsAndStories as $index => $newsAndStory) {
         $id = $newsAndStory['id'];
@@ -59,7 +58,7 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
 
         // Check if the what the feed type is the same as the article type
         if( ($includeNews && $newsAndStory['article-type'] == 'News') || ($includeStories && $newsAndStory['article-type'] == 'Story')) {
-            // TODO: THIS CHECK CAN BE REMOVED
+            // TODO: THIS CHECK CAN BE REMOVED ONCE WE DON't HAVE THE CORNAVIRUS ARTICLE
             if($onlyLookForCoronavirus === True && $galleryStyle == 'Homepage Top Feature' && $id != $coronavirusArticleId){
                 continue;
             }
@@ -82,7 +81,7 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
 //        // exit once there are 3
 //        if( sizeof($threeStories) >= 3)
 //            break;
-        // If its the homepage top feature and we have 2 and the coronavirus isn't in it, we only need to look for the cornavirus article.
+        // TODO: If its the homepage top feature and we have 2 and the coronavirus isn't in it, we only need to look for the cornavirus article.
         if( $galleryStyle == 'Homepage Top Feature' && sizeof($threeStories) == 2 && !in_array($coronavirusArticleId, $GLOBALS['stories-already-used'])) {
             $onlyLookForCoronavirus = True;
         }

--- a/news/php/news_article_gallery_feed.php
+++ b/news/php/news_article_gallery_feed.php
@@ -82,10 +82,10 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
 //        if( sizeof($threeStories) >= 3)
 //            break;
         // If its the homepage top feature and we have 2 and the coronavirus isn't in it, we only need to look for the cornavirus article.
-        if( $galleryStyle == 'Homepage Top Feature' && sizeof($threeStories == 2 ) && !in_array($coronavirusArticleId, $threeStories)) {
+        if( $galleryStyle == 'Homepage Top Feature' && sizeof($threeStories) == 2 && !in_array($coronavirusArticleId, $threeStories)) {
             $onlyLookForCoronavirus = True;
         }
-        elseif( sizeof($threeStories == 3) ) {
+        elseif( sizeof($threeStories) == 3) {
             break;
         }
     }

--- a/news/php/news_article_gallery_feed.php
+++ b/news/php/news_article_gallery_feed.php
@@ -46,9 +46,9 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
     }
 
     $threeStories = array();
+    $onlyLookForCoronavirus = False;
     foreach( $arrayOfNewsAndStories as $index => $newsAndStory) {
         $id = $newsAndStory['id'];
-        $addArticle = false;
         $coronavirusArticleId = 'c0a958b58c5865fc6f6501cb65bc8c89';
 
         // if it's already been used, skip this article
@@ -57,8 +57,12 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
             continue;
 
         // Check if the what the feed type is the same as the article type
-        // The last check is the coronavirus check
-        if( (($includeNews && $newsAndStory['article-type'] == 'News') || ($includeStories && $newsAndStory['article-type'] == 'Story')) || ( $galleryStyle == 'Homepage Top Feature' && $id == $coronavirusArticleId)) {
+        if( ($includeNews && $newsAndStory['article-type'] == 'News') || ($includeStories && $newsAndStory['article-type'] == 'Story')) {
+            // TODO: THIS CHECK CAN BE REMOVED
+            if($onlyLookForCoronavirus === True && $galleryStyle == 'Homepage Top Feature' && $id != $coronavirusArticleId){
+                continue;
+            }
+
             // We add the mybethel class for the community dashboard
             $add_mybethel_class = '';
             if( strpos($_SERVER['REQUEST_URI'], '_portal/') !== false )
@@ -73,9 +77,17 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
             unset($arrayOfNewsAndStories[$index]);
         }
 
-        // exit once there are 3
-        if( sizeof($threeStories) >= 3)
+        // TODO: THIS IS THE DEFAULT CODE, but we don't want to do this while we have the cornavirus locked in position 3
+//        // exit once there are 3
+//        if( sizeof($threeStories) >= 3)
+//            break;
+        // If its the homepage top feature and we have 2, we only need to look for the cornavirus article.
+        if( $galleryStyle == 'Homepage Top Feature' && sizeof($threeStories == 2 )) {
+            $onlyLookForCoronavirus = True;
+        }
+        elseif( sizeof($threeStories == 3) ) {
             break;
+        }
     }
 
     $arrayOfArticles = array_merge($arrayOfArticles, $arrayOfNewsAndStories);

--- a/news/php/news_article_gallery_feed.php
+++ b/news/php/news_article_gallery_feed.php
@@ -29,7 +29,8 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
     $arrayOfArticles = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/articles.xml", $categories, "inspect_news_article"));
 
     // This is the new version of news.
-    $arrayOfNewsAndStories = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article"), 300, $clearCacheBethelAlert);
+//    $arrayOfNewsAndStories = autoCache('get_xml', array($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article"), 300, $clearCacheBethelAlert);
+    $arrayOfNewsAndStories = get_xml($_SERVER["DOCUMENT_ROOT"] . "/_shared-content/xml/news-and-stories.xml", $categories, "inspect_news_article");
 
     $arrayOfNewsAndStories = sort_by_date($arrayOfNewsAndStories);
 

--- a/news/php/news_article_gallery_feed.php
+++ b/news/php/news_article_gallery_feed.php
@@ -47,10 +47,10 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
 
     $threeStories = array();
     $onlyLookForCoronavirus = False;
+    $coronavirusArticleId = 'c0a958b58c5865fc6f6501cb65bc8c89';
+
     foreach( $arrayOfNewsAndStories as $index => $newsAndStory) {
         $id = $newsAndStory['id'];
-        $coronavirusArticleId = 'c0a958b58c5865fc6f6501cb65bc8c89';
-
         // if it's already been used, skip this article
         // if its the Homepage Top Feature, skip any that aren't tagged as homepage
         if( in_array($id, $GLOBALS['stories-already-used']) || ($galleryStyle == 'Homepage Top Feature' && !$newsAndStory['homepage-article']) )
@@ -81,8 +81,8 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
 //        // exit once there are 3
 //        if( sizeof($threeStories) >= 3)
 //            break;
-        // If its the homepage top feature and we have 2, we only need to look for the cornavirus article.
-        if( $galleryStyle == 'Homepage Top Feature' && sizeof($threeStories == 2 )) {
+        // If its the homepage top feature and we have 2 and the coronavirus isn't in it, we only need to look for the cornavirus article.
+        if( $galleryStyle == 'Homepage Top Feature' && sizeof($threeStories == 2 ) && !in_array($coronavirusArticleId, $threeStories)) {
             $onlyLookForCoronavirus = True;
         }
         elseif( sizeof($threeStories == 3) ) {

--- a/news/php/news_article_gallery_feed.php
+++ b/news/php/news_article_gallery_feed.php
@@ -83,7 +83,7 @@ function create_news_article_gallery_feed($categories, $galleryStyle, $myBethel,
 //        if( sizeof($threeStories) >= 3)
 //            break;
         // If its the homepage top feature and we have 2 and the coronavirus isn't in it, we only need to look for the cornavirus article.
-        if( $galleryStyle == 'Homepage Top Feature' && sizeof($threeStories) == 2 && !in_array($coronavirusArticleId, $threeStories)) {
+        if( $galleryStyle == 'Homepage Top Feature' && sizeof($threeStories) == 2 && !in_array($coronavirusArticleId, $GLOBALS['stories-already-used'])) {
             $onlyLookForCoronavirus = True;
         }
         elseif( sizeof($threeStories) == 3) {


### PR DESCRIPTION
## Description

Marketing (Fiona) requested that we make it so the Coronavirus article stays in the top 3 on the homepage.

The basic logic is as follows: If we don't include the coronavirus article in the first 2 of 3, then we will ONLY be looking for the coronavirus article. This only occurs if its the top homepage feature.

I added some temporary checks that will need to be removed when the time comes.

## Size and Type of change

- Small Change - 1 person needs to review this
- New feature
- Contact Fiona

## How Has This Been Tested?

- I tested on staging with this branch. I tested it without cacheing.
- I made sure that it loaded every as expected with the current articles
- I then checked to see if I removed one of the current 3 articles that it would add a 3rd - it did.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)