### PR TITLE
Fix bethel alerts

### DIFF
--- a/events/php/event_feed.php
+++ b/events/php/event_feed.php
@@ -174,7 +174,7 @@ function inspect_event_page($xml, $categories){
     $ds = $xml->{'system-data-structure'};
 
     $options = array('general', 'offices', 'academic-dates', 'cas-departments', 'adult-undergrad-program', 'graduate-program', 'seminary-program', 'internal');
-    $page_info['display-on-feed'] = match_metadata_articles($xml, $categories, $options, "event");
+    $page_info['display-on-feed'] = match_metadata_articles($xml, $categories, $options);
 
     $dataDefinition = $ds['definition-path'];
 

--- a/general-cascade/feed_helper.php
+++ b/general-cascade/feed_helper.php
@@ -56,9 +56,6 @@ function match_metadata_articles($xml, $categories, $options){
 
                 if (in_array($name, $options)) {
                     if (in_array($value, $category)) {
-
-                        print_r($value. " " . join(",", $category). "|");
-
                         return true;
                     }
                 }

--- a/general-cascade/feed_helper.php
+++ b/general-cascade/feed_helper.php
@@ -44,7 +44,7 @@ function create_featured_array($featuredOptions){
     return $featured;
 }
 
-function match_metadata_articles($xml, $categories, $options, $feedType){
+function match_metadata_articles($xml, $categories, $options){
     foreach( $categories as $category) {
         foreach ($xml->{'dynamic-metadata'} as $md) {
             $name = $md->name;
@@ -53,12 +53,11 @@ function match_metadata_articles($xml, $categories, $options, $feedType){
                 if (strtolower($value) == "none" || strtolower($value) == "select") {
                     continue;
                 }
-                // Todo: why was this here?? Removing this causes event feeds to work.
-//                if ($feedType == 'event')
-//                    $value = htmlspecialchars($value);
 
                 if (in_array($name, $options)) {
                     if (in_array($value, $category)) {
+                        print_r($value. " " . $category. "|");
+
                         return true;
                     }
                 }

--- a/general-cascade/feed_helper.php
+++ b/general-cascade/feed_helper.php
@@ -56,7 +56,8 @@ function match_metadata_articles($xml, $categories, $options){
 
                 if (in_array($name, $options)) {
                     if (in_array($value, $category)) {
-                        print_r($value. " " . $category. "|");
+
+                        print_r($value. " " . join(",", $category). "|");
 
                         return true;
                     }

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -21,8 +21,7 @@ $DisplayImages;
 $featuredArticleOptions;
 
 function create_news_article_feed($categories, $blerts="No"){
-//    $feed = autoCache("create_news_article_feed_logic", array($categories, $blerts), 300, $blerts);
-    $feed = create_news_article_feed_logic($categories, $blerts);
+    $feed = autoCache("create_news_article_feed_logic", array($categories, $blerts), 300, $blerts);
     return $feed;
 }
 

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -168,7 +168,7 @@ function inspect_news_article($xml, $categories){
         $page_info['image'] = srcset($page_info['image-path'], $print = false, $lazy = true, $classes = $add_mybethel_class, $page_info['title']);
     }
 
-    $page_info['metadata_articles'] = match_metadata_articles($xml, $categories, $options, "news");
+    $page_info['metadata_articles'] = match_metadata_articles($xml, $categories, $options);
     $page_info['is_expired'] = is_expired($page_info['date-for-sorting']);
 
     if( $page_info['metadata_articles'] && !$page_info['is_expired'] ) {

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -171,6 +171,8 @@ function inspect_news_article($xml, $categories){
     // if its a bethel alert, always pass it on to be checked by the feed code!
     if($page_info['bethel-alert'] == 'No') {
         $page_info['metadata_articles'] = match_metadata_articles($xml, $categories, $options);
+    } else {
+        $page_info['metadata_articles'] = true;
     }
     $page_info['is_expired'] = is_expired($page_info['date-for-sorting']);
 

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -168,7 +168,10 @@ function inspect_news_article($xml, $categories){
         $page_info['image'] = srcset($page_info['image-path'], $print = false, $lazy = true, $classes = $add_mybethel_class, $page_info['title']);
     }
 
-    $page_info['metadata_articles'] = match_metadata_articles($xml, $categories, $options);
+    // if its a bethel alert, always pass it on to be checked by the feed code!
+    if($page_info['bethel-alert'] == 'No') {
+        $page_info['metadata_articles'] = match_metadata_articles($xml, $categories, $options);
+    }
     $page_info['is_expired'] = is_expired($page_info['date-for-sorting']);
 
     if( $page_info['metadata_articles'] && !$page_info['is_expired'] ) {

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -51,16 +51,16 @@ function create_news_article_feed_logic($categories, $blerts){
         $id = $article['id'];
         
         // ejc84332 temporarily(?) skip any articles that are not alerts if this feed is set to show alerts.
-        if( $blerts != "No" and $article['bethel-alert'] == "No"){
-            continue;
-        }
+//        if( $blerts != "No" and $article['bethel-alert'] == "No"){
+//            continue;
+//        }
         
         if( !in_array($id, $GLOBALS['stories-already-used']) ){
             // If the news feed is set to use blerts, we check to make sure they include the values we want, else continue
             // if we include public alerts, then we only want to skip internal ones
             // if we don't want blerts, then we skip all blerts
             // if we want to include internal, then we don't skip any
-            if( ($blerts == 'Yes - Public Bethel Alert' and $article['bethel-alert'] == 'Internal Bethel Alert')
+            if( ($blerts != 'Yes - Internal Bethel Alert' and $article['bethel-alert'] == 'Internal Bethel Alert')
                 or ($blerts == 'No' and $article['bethel-alert'] != 'No')){
                 continue;
             }

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -51,11 +51,6 @@ function create_news_article_feed_logic($categories, $blerts){
     foreach( $sortedArticles as $article ){
         $id = $article['id'];
         
-        // ejc84332 temporarily(?) skip any articles that are not alerts if this feed is set to show alerts.
-//        if( $blerts != "No" and $article['bethel-alert'] == "No"){
-//            continue;
-//        }
-        
         if( !in_array($id, $GLOBALS['stories-already-used']) ){
             // If the news feed is set to use blerts, we check to make sure they include the values we want, else continue
             // if we include public alerts, then we only want to skip internal ones

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -21,7 +21,8 @@ $DisplayImages;
 $featuredArticleOptions;
 
 function create_news_article_feed($categories, $blerts="No"){
-    $feed = autoCache("create_news_article_feed_logic", array($categories, $blerts), 300, $blerts);
+//    $feed = autoCache("create_news_article_feed_logic", array($categories, $blerts), 300, $blerts);
+    $feed = create_news_article_feed_logic($categories, $blerts);
     return $feed;
 }
 

--- a/news/php/news_articles_archive.php
+++ b/news/php/news_articles_archive.php
@@ -130,7 +130,7 @@ function inspect_news_archive_page($xml, $categories){
             $page_info['display-on-feed'] = true;
         } elseif( $dataDefinition == "News Article") {
             $options = array('school', 'topic', 'department', 'adult-undergrad-program', 'graduate-program', 'seminary-program', 'unique-news');
-            $page_info['display-on-feed'] = match_metadata_articles($xml, $categories, $options, "news");
+            $page_info['display-on-feed'] = match_metadata_articles($xml, $categories, $options);
         } elseif( $dataDefinition == "News Article - Flex") {
             $page_info['bethel-alert'] = $ds->{'story-metadata'}->{'bethel-alert'};
         }


### PR DESCRIPTION
## Description

This fixed the issue where the bethel.edu/bethel-alerts feed was not able to ONLY show bethel alerts. I updated the code to allow bethel alerts to always be checked in the feed code, instead of just in the "gather metadata" code. I also removed the hotfix code Eric added.

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

- I tested the homepage, news homepage, news archive, and bethel alert feed page. They all successfully displayed the articles/alerts.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)