### PR TITLE
Add news offices

### DIFF
--- a/general-cascade/feed_helper.php
+++ b/general-cascade/feed_helper.php
@@ -56,8 +56,6 @@ function match_metadata_articles($xml, $categories, $options){
 
                 if (in_array($name, $options)) {
                     if (in_array($value, $category)) {
-                        print_r($value);
-                        print_r($category);
                         return true;
                     }
                 }

--- a/general-cascade/feed_helper.php
+++ b/general-cascade/feed_helper.php
@@ -56,6 +56,8 @@ function match_metadata_articles($xml, $categories, $options){
 
                 if (in_array($name, $options)) {
                     if (in_array($value, $category)) {
+                        print_r($value);
+                        print_r($category);
                         return true;
                     }
                 }

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -178,9 +178,6 @@ function inspect_news_article($xml, $categories){
     $page_info['display-date'] = format_featured_date_news_article($page_info['date-for-sorting']);
     $page_info['html'] = get_news_article_html($page_info);
 
-    if( $page_info['display-on-feed'] == true )
-        print_r($page_info['html']);
-
     return $page_info;
 }
 

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -63,7 +63,7 @@ function create_news_article_feed_logic($categories, $blerts){
 
             array_push($articleArray, $article['html']);
 
-            print_r($article['html']);
+            print_r($article);
 
             // don't use this story on this page again
             array_push($GLOBALS['stories-already-used'], $id);

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -21,14 +21,12 @@ $DisplayImages;
 $featuredArticleOptions;
 
 function create_news_article_feed($categories, $blerts="No"){
-//    $feed = autoCache("create_news_article_feed_logic", array($categories, $blerts), 300, $blerts);
-    $feed = create_news_article_feed_logic($categories, $blerts);
+    $feed = autoCache("create_news_article_feed_logic", array($categories, $blerts), 300, $blerts);
     return $feed;
 }
 
 // returns an array of html elements.
 function create_news_article_feed_logic($categories, $blerts){
-    print_r($categories);
     include_once $_SERVER["DOCUMENT_ROOT"] . "/code/php_helper_for_cascade.php";
     include_once $_SERVER["DOCUMENT_ROOT"] . "/code/general-cascade/feed_helper.php";
 
@@ -63,8 +61,6 @@ function create_news_article_feed_logic($categories, $blerts){
             }
 
             array_push($articleArray, $article['html']);
-
-            print_r($article['xml']);
 
             // don't use this story on this page again
             array_push($GLOBALS['stories-already-used'], $id);
@@ -108,8 +104,7 @@ function inspect_news_article($xml, $categories){
         "display-on-feed"           => false,
         "id"                        => (string)$xml['id'],
         "featured-homepage-article" => false,
-        "bethel-alert"              => 'No',
-        "xml"                       => $xml
+        "bethel-alert"              => 'No'
     );
 
     // if the file doesn't exist, skip it.

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -178,6 +178,9 @@ function inspect_news_article($xml, $categories){
     $page_info['display-date'] = format_featured_date_news_article($page_info['date-for-sorting']);
     $page_info['html'] = get_news_article_html($page_info);
 
+    if( $page_info['display-on-feed'])
+        print_r($page_info['html']);
+
     return $page_info;
 }
 

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -120,7 +120,7 @@ function inspect_news_article($xml, $categories){
     // To get the correct definition path.
     $ddp = $ds['definition-path'];
 
-    $options = array('school', 'topic', 'department', 'adult-undergrad-program', 'graduate-program', 'seminary-program', 'unique-news');
+    $options = array('school', 'topic', 'department', 'adult-undergrad-program', 'graduate-program', 'seminary-program', 'office', 'unique-news');
     if( $ddp == "News Article") {
         $page_info['image-path'] = (string)$ds->{'media'}->{'image'}->{'path'};
         // set external path, if available

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -63,6 +63,8 @@ function create_news_article_feed_logic($categories, $blerts){
 
             array_push($articleArray, $article['html']);
 
+            print_r($article['html']);
+
             // don't use this story on this page again
             array_push($GLOBALS['stories-already-used'], $id);
         }

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -178,7 +178,7 @@ function inspect_news_article($xml, $categories){
     $page_info['display-date'] = format_featured_date_news_article($page_info['date-for-sorting']);
     $page_info['html'] = get_news_article_html($page_info);
 
-    if( $page_info['display-on-feed'])
+    if( $page_info['display-on-feed'] == true )
         print_r($page_info['html']);
 
     return $page_info;

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -28,6 +28,7 @@ function create_news_article_feed($categories, $blerts="No"){
 
 // returns an array of html elements.
 function create_news_article_feed_logic($categories, $blerts){
+    print_r($categories);
     include_once $_SERVER["DOCUMENT_ROOT"] . "/code/php_helper_for_cascade.php";
     include_once $_SERVER["DOCUMENT_ROOT"] . "/code/general-cascade/feed_helper.php";
 
@@ -63,7 +64,7 @@ function create_news_article_feed_logic($categories, $blerts){
 
             array_push($articleArray, $article['html']);
 
-            print_r($article);
+            print_r($article['xml']);
 
             // don't use this story on this page again
             array_push($GLOBALS['stories-already-used'], $id);

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -21,7 +21,8 @@ $DisplayImages;
 $featuredArticleOptions;
 
 function create_news_article_feed($categories, $blerts="No"){
-    $feed = autoCache("create_news_article_feed_logic", array($categories, $blerts), 300, $blerts);
+//    $feed = autoCache("create_news_article_feed_logic", array($categories, $blerts), 300, $blerts);
+    $feed = create_news_article_feed_logic($categories, $blerts);
     return $feed;
 }
 

--- a/news/php/news_article_feed.php
+++ b/news/php/news_article_feed.php
@@ -108,7 +108,8 @@ function inspect_news_article($xml, $categories){
         "display-on-feed"           => false,
         "id"                        => (string)$xml['id'],
         "featured-homepage-article" => false,
-        "bethel-alert"              => 'No'
+        "bethel-alert"              => 'No',
+        "xml"                       => $xml
     );
 
     // if the file doesn't exist, skip it.

--- a/news/php/news_articles_archive.php
+++ b/news/php/news_articles_archive.php
@@ -129,7 +129,7 @@ function inspect_news_archive_page($xml, $categories){
         if( $dataDefinition == "News Article - President" ){
             $page_info['display-on-feed'] = true;
         } elseif( $dataDefinition == "News Article") {
-            $options = array('school', 'topic', 'department', 'adult-undergrad-program', 'graduate-program', 'seminary-program', 'unique-news');
+            $options = array('school', 'topic', 'department', 'adult-undergrad-program', 'graduate-program', 'seminary-program', 'office', 'unique-news');
             $page_info['display-on-feed'] = match_metadata_articles($xml, $categories, $options);
         } elseif( $dataDefinition == "News Article - Flex") {
             $page_info['bethel-alert'] = $ds->{'story-metadata'}->{'bethel-alert'};


### PR DESCRIPTION
## Description

Judd from Marketing added a new field to the Robust metadata: offices. This is now added to news.

## Size and Type of change

- Small Change - 1 person needs to review this
- New feature

## How Has This Been Tested?

- I tested through my commits of adding print statements. I used one of my test news feeds to make it so only the new office field was pulling, which it did.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)