### PR TITLE
change image link to article link

### DIFF
--- a/news/twig/mybethel_news_feed.html
+++ b/news/twig/mybethel_news_feed.html
@@ -7,7 +7,7 @@
             />
         </div>
         <div class="media-body">
-            <h3 class="u-fs16  u-fw500"><a href="https://bethel-university.imgix.net/{{ article['image-path'] }}">{{ article['title'] }}</a></h3>
+            <h3 class="u-fs16  u-fw500"><a href="https://bethel.edu/{{ article['path'] }}">{{ article['title'] }}</a></h3>
             {% if article['teaser'] %}
                 <p>{{ article['teaser'] }}</p>
             {% endif %}


### PR DESCRIPTION
## Description

Instead of displaying image display article when clicking on link per Judd's orders\

## Size and Type of change

- Small Change - 1 person needs to review this

## How Has This Been Tested?

Tested on staging and the link went to the article instead of image 

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)