### PR TITLE
Fix Sorting of events

### DIFF
--- a/events/php/event_feed.php
+++ b/events/php/event_feed.php
@@ -95,16 +95,11 @@ function create_event_feed_logic($categories, $heading){
     }
 
     /////////////////////////////////////////
-    $sortedEvents = array_reverse(sort_by_date($eventArrayWithMultipleEvents));
-    // Only grab the first X number of events.
-    global $NumEvents;
 
-    $numEventsToFind = $NumEvents;
-
-    $eventArray = array();
-    foreach( $sortedEvents as $event)
+    $allEventArray = array();
+    foreach( $eventArrayWithMultipleEvents as $event)
     {
-        array_push( $eventArray, $event['html']);
+        array_push( $allEventArray, $event);
 
         // Checks for events that are more than a day long
         $lengthOfEvent = $event['end-date'] - $event['start-date'];
@@ -115,9 +110,23 @@ function create_event_feed_logic($categories, $heading){
             $date = date('Y-m-d H:i:s', strtotime($date . ' +1 day'));
             $event['date']['start-date'] = strtotime($date);
             $event['html'] = get_event_html($event);
+            $event['date-for-sorting'] = $event['date']['start-date'] / 1000;
             $lengthOfEvent -= 86400;
-            array_push( $eventArray, $event['html']);
+            array_push( $allEventArray, $event);
         }
+    }
+
+    $sortedEvents = array_reverse(sort_by_date($allEventArray));
+    // Only grab the first X number of events.
+    global $NumEvents;
+
+    $numEventsToFind = $NumEvents;
+
+    $eventArray = array();
+
+    foreach( $sortedEvents as $event)
+    {
+        array_push( $eventArray, $event['html']);
     }
 
     $eventArray = array_slice($eventArray, 0, $numEventsToFind, true);


### PR DESCRIPTION
## Description

Fixes an issue in my code before where the events that extend over a day are separated into separate events per day but are sorted incorrectly. This update should fix the sorting so all the events that are more than a day long don't all appear together in the feeds.

Fixes # (Judd requested this. No case number as far as I know)

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

I made changes in the code, committed my changes to a branch, and checked out this branch on the staging server. I then checked the changes in staging.bethel.edu and the event feeds looked correct.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)