### PR TITLE
Fix event order

### DIFF
--- a/events/php/event_feed.php
+++ b/events/php/event_feed.php
@@ -105,7 +105,7 @@ function create_event_feed_logic($categories, $heading){
 
         // Checks for events that are more than a day long
         $lengthOfEvent = $event['end-date'] - $event['start-date'];
-        // Convert timestamp so it can add a day. It is converted back later
+        // Convert timestamp so it can add a day per day of the event. It is converted back later
         $date = date("Y-m-d H:i:s", $event['start-date']);
         // While the event is longer than a day (86400 seconds), post event to screen
         while ($lengthOfEvent >= 86400) {

--- a/events/php/event_feed.php
+++ b/events/php/event_feed.php
@@ -112,11 +112,11 @@ function create_event_feed_logic($categories, $heading){
             $event['html'] = get_event_html($event);
             $event['date-for-sorting'] = $event['date']['start-date'] / 1000;
             $lengthOfEvent -= 86400;
-            echo "<p>" + $event['date-for-sorting'] + "</p>";
+            echo "<p>" + $event['date']['start-date'] + "</p>";
             echo "<br>";
             echo "<p>" + time() + "</p>";
             echo "<br>";
-            if($event['date-for-sorting'] >= time()) {
+            if($event['date']['start-date'] >= time()) {
                 array_push( $allEventArray, $event);
             }
         }

--- a/events/php/event_feed.php
+++ b/events/php/event_feed.php
@@ -99,7 +99,9 @@ function create_event_feed_logic($categories, $heading){
     $allEventArray = array();
     foreach( $eventArrayWithMultipleEvents as $event)
     {
-        array_push( $allEventArray, $event);
+        if($event['date']['start-date'] >= time()) {
+            array_push( $allEventArray, $event);
+        }
 
         // Checks for events that are more than a day long
         $lengthOfEvent = $event['end-date'] - $event['start-date'];

--- a/events/php/event_feed.php
+++ b/events/php/event_feed.php
@@ -105,7 +105,7 @@ function create_event_feed_logic($categories, $heading){
 
         // Checks for events that are more than a day long
         $lengthOfEvent = $event['end-date'] - $event['start-date'];
-        // Convert timestamp to add a day. It is converted back later
+        // Convert timestamp so it can add a day. It is converted back later
         $date = date("Y-m-d H:i:s", $event['start-date']);
         // While the event is longer than a day (86400 seconds), post event to screen
         while ($lengthOfEvent >= 86400) {
@@ -114,10 +114,7 @@ function create_event_feed_logic($categories, $heading){
             $event['html'] = get_event_html($event);
             $event['date-for-sorting'] = $event['date']['start-date'] / 1000;
             $lengthOfEvent -= 86400;
-            echo "<p>" + $event['date']['start-date'] + "</p>";
-            echo "<br>";
-            echo "<p>" + time() + "</p>";
-            echo "<br>";
+            
             if($event['date']['start-date'] >= time()) {
                 array_push( $allEventArray, $event);
             }

--- a/events/php/event_feed.php
+++ b/events/php/event_feed.php
@@ -112,6 +112,8 @@ function create_event_feed_logic($categories, $heading){
             $event['html'] = get_event_html($event);
             $event['date-for-sorting'] = $event['date']['start-date'] / 1000;
             $lengthOfEvent -= 86400;
+            echo "<p>" + $event['date-for-sorting'] + "</p>";
+            echo "<p>" + time() + "</p>";
             if($event['date-for-sorting'] < time()) {
                 array_push( $allEventArray, $event);
             }

--- a/events/php/event_feed.php
+++ b/events/php/event_feed.php
@@ -112,9 +112,11 @@ function create_event_feed_logic($categories, $heading){
             $event['html'] = get_event_html($event);
             $event['date-for-sorting'] = $event['date']['start-date'] / 1000;
             $lengthOfEvent -= 86400;
-            echo "<p>" + $event['date-for-sorting'] + "</p><br>";
-            echo "<p>" + time() + "</p><br>";
-            if($event['date-for-sorting'] < time()) {
+            echo "<p>" + $event['date-for-sorting'] + "</p>";
+            echo "<br>";
+            echo "<p>" + time() + "</p>";
+            echo "<br>";
+            if($event['date-for-sorting'] >= time()) {
                 array_push( $allEventArray, $event);
             }
         }

--- a/events/php/event_feed.php
+++ b/events/php/event_feed.php
@@ -112,7 +112,9 @@ function create_event_feed_logic($categories, $heading){
             $event['html'] = get_event_html($event);
             $event['date-for-sorting'] = $event['date']['start-date'] / 1000;
             $lengthOfEvent -= 86400;
-            array_push( $allEventArray, $event);
+            if($event['date-for-sorting'] < time()) {
+                array_push( $allEventArray, $event);
+            }
         }
     }
 

--- a/events/php/event_feed.php
+++ b/events/php/event_feed.php
@@ -112,8 +112,8 @@ function create_event_feed_logic($categories, $heading){
             $event['html'] = get_event_html($event);
             $event['date-for-sorting'] = $event['date']['start-date'] / 1000;
             $lengthOfEvent -= 86400;
-            echo "<p>" + $event['date-for-sorting'] + "</p>";
-            echo "<p>" + time() + "</p>";
+            echo "<p>" + $event['date-for-sorting'] + "</p><br>";
+            echo "<p>" + time() + "</p><br>";
             if($event['date-for-sorting'] < time()) {
                 array_push( $allEventArray, $event);
             }


### PR DESCRIPTION
## Description

I made a bug previously where an event that spanned multiple days would show every day of the event even if that day passed. Now it should only show current and upcoming events.

Fixes # N/A

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

I committed my changes to a branch and checked out the branch on staging. Everything looked good. Past events don't show up and the ordering is good.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)