### PR TITLE
use display names if available for concentrations

### DIFF
--- a/program-search/php/program-search-functions.php
+++ b/program-search/php/program-search-functions.php
@@ -138,7 +138,10 @@ function inspect_program($xml){
             if( $page_info['display-name'] != '' ){
                 $temp_concentration['title'] = $page_info['display-name'];
             } elseif( $temp_concentration['concentration_page']->{'path'} != '/' ) {
-                $temp_concentration['title'] = strval($temp_concentration['concentration_page']->{'title'});
+                if( strval($temp_concentration['concentration_page']->{'display-name'}) != '' )
+                    $temp_concentration['title'] = strval($temp_concentration['concentration_page']->{'display-name'});
+                else
+                    $temp_concentration['title'] = strval($temp_concentration['concentration_page']->{'title'});
                 $temp_concentration['title'] = str_replace('Program Details', '', $temp_concentration['title']);
                 $temp_concentration['title'] = str_replace('Concentration', '', $temp_concentration['title']);
                 $temp_concentration['title'] = str_replace('Major', '', $temp_concentration['title']);


### PR DESCRIPTION
## Description

use display-name for concentrations by default

Fixes # https://betheluniversity.atlassian.net/browse/ITS-261471

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

locally and XP and prod

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)