### PR TITLE
get dates from "News Article - Fixed"

### DIFF
--- a/news/php/news_articles_archive.php
+++ b/news/php/news_articles_archive.php
@@ -111,6 +111,8 @@ function inspect_news_archive_page($xml, $categories){
             $date_for_sorting = $ds->{'story-metadata'}->{'publish-date'} / 1000;
         } elseif( $dataDefinition == "News Article - President" ){
             $date_for_sorting = $ds->{'publish-date'} / 1000;
+        } elseif( $dataDefinition == "News Article - Fixed" ) {
+            $date_for_sorting = $ds->{'publish-date'} / 1000;
         } else {
             // todo: this probably isn't needed, but we should have some default value
             $date_for_sorting = $ds->{'story-metadata'}->{'publish-date'} / 1000;


### PR DESCRIPTION
## Description

Get dates from "News Article - Fixed" so that articles created before 2019 will display in the news archive feed.

Fixes # T2505-10444

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

XP and Prod

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)